### PR TITLE
Separate the Obs request from the all encounters request to improve efficiency

### DIFF
--- a/src/care-and-treatment/care-treatment-config.json
+++ b/src/care-and-treatment/care-treatment-config.json
@@ -5,6 +5,7 @@
       "tabName": "New Visit",
       "headerTitle": "New Visit",
       "displayText": "New Visit",
+      "encounterType": "visitEncounterType",
       "columns": [
         {
           "id": "weight",
@@ -81,6 +82,7 @@
       "tabName": "Opportunistic Infections",
       "headerTitle": "Opportunistic Infections",
       "displayText": "Opportunistic Infections",
+      "encounterType": "oiEncounterType",
       "columns": [
         {
           "id": "encounterDate",
@@ -149,6 +151,7 @@
       "tabName": "Hospitalization",
       "headerTitle": "Hospitalization",
       "displayText": "Hospitalization",
+      "encounterType": "hospitalizationEncounterType",
       "columns": [
         {
           "id": "encounterDate",

--- a/src/encounters/encounterObservations.tsx
+++ b/src/encounters/encounterObservations.tsx
@@ -1,18 +1,22 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { SkeletonText } from "@carbon/react";
+import { InlineLoading } from "@carbon/react";
 import { useConfig } from "@openmrs/esm-framework";
-import { type Observation } from "./encounters.resource";
+import { ErrorState } from "@openmrs/esm-patient-common-lib";
+import { useEncounterObservations } from "./encounters.resource";
 import styles from "./encounterObservations.scss";
 
 interface EncounterObservationsProps {
-  observations: Array<Observation>;
+  encounterUuid: string;
 }
 
 const EncounterObservations: React.FC<EncounterObservationsProps> = ({
-  observations,
+  encounterUuid,
 }) => {
   const { t } = useTranslation();
+  const { observations, isLoading, error } =
+    useEncounterObservations(encounterUuid);
+
   const { obsConceptUuidsToHide = [] } = useConfig();
 
   function getAnswerFromDisplay(display: string): string {
@@ -24,52 +28,60 @@ const EncounterObservations: React.FC<EncounterObservationsProps> = ({
     }
   }
 
-  if (!observations) {
-    return <SkeletonText />;
-  }
-
-  if (observations) {
-    const filteredObservations = obsConceptUuidsToHide.length
-      ? observations?.filter((obs) => {
-          return !obsConceptUuidsToHide.includes(obs?.concept?.uuid);
-        })
-      : observations;
+  if (isLoading) {
     return (
-      <div className={styles.observation}>
-        {filteredObservations?.map((obs, index) => {
-          if (obs.groupMembers) {
-            return (
-              <React.Fragment key={index}>
-                <span className={styles.parentConcept}>
-                  {obs.concept.display}
-                </span>
-                <span />
-                {obs.groupMembers.map((member) => (
-                  <React.Fragment key={index}>
-                    <span className={styles.childConcept}>
-                      {member.concept.display}
-                    </span>
-                    <span>{getAnswerFromDisplay(member.display)}</span>
-                  </React.Fragment>
-                ))}
-              </React.Fragment>
-            );
-          } else {
-            return (
-              <React.Fragment key={index}>
-                <span>{obs.concept.display}</span>
-                <span>{getAnswerFromDisplay(obs.display)}</span>
-              </React.Fragment>
-            );
-          }
-        })}
-      </div>
+      <InlineLoading
+        description={`${t("loadingObs", "Loading Observations")} ...`}
+        role="progressbar"
+      />
     );
   }
 
+  if (error) {
+    return (
+      <ErrorState headerTitle={t("encounters", "Encounters")} error={error} />
+    );
+  }
+
+  if (observations.length === 0) {
+    return <p>{t("noObservationsFound", "No observations found")}</p>;
+  }
+
+  const filteredObservations = obsConceptUuidsToHide.length
+    ? observations?.filter((obs) => {
+        return !obsConceptUuidsToHide.includes(obs?.concept?.uuid);
+      })
+    : observations;
+
   return (
     <div className={styles.observation}>
-      <p>{t("noObservationsFound", "No observations found")}</p>
+      {filteredObservations?.map((obs, index) => {
+        if (obs.groupMembers) {
+          return (
+            <React.Fragment key={index}>
+              <span className={styles.parentConcept}>
+                {obs.concept.display}
+              </span>
+              <span />
+              {obs.groupMembers.map((member) => (
+                <React.Fragment key={index}>
+                  <span className={styles.childConcept}>
+                    {member.concept.display}
+                  </span>
+                  <span>{getAnswerFromDisplay(member.display)}</span>
+                </React.Fragment>
+              ))}
+            </React.Fragment>
+          );
+        } else {
+          return (
+            <React.Fragment key={index}>
+              <span>{obs.concept.display}</span>
+              <span>{getAnswerFromDisplay(obs.display)}</span>
+            </React.Fragment>
+          );
+        }
+      })}
     </div>
   );
 };

--- a/src/encounters/encounters.component.tsx
+++ b/src/encounters/encounters.component.tsx
@@ -361,7 +361,7 @@ const EncountersTable: React.FC<EncountersTableProps> = ({ patientUuid }) => {
                           colSpan={headers.length + 2}
                         >
                           <EncounterObservations
-                            observations={selectedEncounter?.obs}
+                            encounterUuid={selectedEncounter?.uuid}
                           />
                         </TableExpandedRow>
                       ) : (

--- a/src/encounters/encounters.resource.ts
+++ b/src/encounters/encounters.resource.ts
@@ -126,7 +126,7 @@ export function useInfiniteEncounters(patientUuid: string) {
       return null;
     }
 
-    let url = `${restBaseUrl}/encounter?patient=${patientUuid}&v=${encounterRepresentation}&limit=${pageSize}&totalCount=true`;
+    let url = `${restBaseUrl}/encounter?patient=${patientUuid}&v=${encounterRepresentation}&order=desc&limit=${pageSize}`;
 
     if (pageIndex) {
       url += `&startIndex=${pageIndex * pageSize}`;

--- a/src/encounters/encounters.resource.ts
+++ b/src/encounters/encounters.resource.ts
@@ -78,13 +78,16 @@ export interface Observation {
   value: unknown;
   obsDatetime?: string;
 }
+export const encounterRepresentation =
+  "custom:(uuid,encounterDatetime,encounterType,encounterProviders:(uuid,provider:(name))," +
+  "form:(uuid,name,display))";
 
 export function useEncounters(patientUuid: string) {
   const endpointUrl = `${restBaseUrl}/encounter`;
   const params = {
     patient: patientUuid,
-    v: "default",
-    limit: "100",
+    v: encounterRepresentation,
+    totalCount: true,
   };
   const fullRequest =
     endpointUrl +
@@ -106,12 +109,6 @@ export function useEncounters(patientUuid: string) {
     mutate,
   };
 }
-
-export const encounterRepresentation =
-  "custom:(uuid,encounterDatetime,encounterType,location:(uuid,name)," +
-  "patient:(uuid,display,age,person),encounterProviders:(uuid,display,provider:(uuid,name))," +
-  "obs:(uuid,display,obsDatetime,voided,groupMembers,concept:(uuid,display:(uuid,display)),value:(uuid,name:(uuid,name)," +
-  "names:(uuid,conceptNameType,name))),form:(uuid,name,display))";
 
 export function useInfiniteEncounters(patientUuid: string) {
   const [stopFetching, setStopFetching] = useState(false);
@@ -172,6 +169,22 @@ export function useInfiniteEncounters(patientUuid: string) {
   };
 }
 
+export function useEncounterObservations(encounterUuid: string) {
+  const { data, isLoading, error } = useSWR<
+    { data: { results: Array<Observation> } },
+    Error
+  >(
+    `${restBaseUrl}/obs?encounter=${encounterUuid}&v=custom:(uuid,display,obsDatetime,voided,groupMembers,concept:(uuid,display:(uuid,display))`,
+    openmrsFetch
+  );
+
+  return {
+    observations: data ? data?.data?.results : null,
+    isLoading,
+    error,
+  };
+}
+
 export function deleteEncounter(
   encounterUuid: string,
   abortController: AbortController
@@ -190,7 +203,9 @@ export const transformToMappedEncounter = (data) => {
     ...data,
     id: data.uuid,
     encounterType: data.encounterType?.display ?? "--",
-    provider: data.encounterProviders[0]?.display ?? "--",
+    provider: data?.encounterProviders
+      ? data?.encounterProviders[0]?.provider.name
+      : "--",
     formName: data.form?.display ?? "--",
     formUuid: data.form?.uuid,
     encounterDatetime: formatDatetime(parseDate(data?.encounterDatetime)),


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.

#### For changes to apps
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [x] My work includes tests or is validated by existing tests.

## Summary
- This PR removes `obs` from the `encounters` request to improve the response time.
- Fetch obs independently when the table row is expanded
- Adds sorting

## Screenshots
<img width="1676" alt="Screenshot 2024-07-16 at 18 23 44" src="https://github.com/user-attachments/assets/df015a88-6e77-4016-935f-1fb3ed0f44dd">

- Loading Encounters
<img width="1728" alt="Screenshot 2024-07-16 at 18 26 34" src="https://github.com/user-attachments/assets/81b64dfc-8bce-4835-9910-8874421e5e9d">



## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
<!-- *None* -->

## Other
<!-- Anything not covered above -->
<!-- *None* -->
