### PR TITLE
(fix) Add job to install plugin that provides yarn version

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -55,16 +55,17 @@ jobs:
         run: |
           git config user.name "GitHub Actions Bot"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-      - name: Bump Patch Version and Publish
-        run: |
-          echo "Bumping patch version for main branch..."
-          git pull origin main
-          yarn version patch --message "chore: bump version to %s [skip ci]"
-          echo "Version bumped to: $(node -p \"require('./package.json').version\")"
-          git push --follow-tags
-          echo "Publishing patch release to NPM..."
-          yarn config set npmAuthToken "${NODE_AUTH_TOKEN}"
-          yarn npm publish --access public
+          - name: Bump Patch Version and Publish
+          run: |
+            echo "Bumping patch version for main branch..."
+            git pull origin main
+            yarn plugin import version
+            yarn version patch --message "chore: bump version to %s [skip ci]"
+            echo "Version bumped to: $(node -p \"require('./package.json').version\")"
+            git push --follow-tags
+            echo "Publishing patch release to NPM..."
+            yarn config set npmAuthToken "${NODE_AUTH_TOKEN}"
+            yarn npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Requirements
- [ ] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.

## Summary
There was an error Usage `Error: Couldn't find a script named "version", but a matching command can be found in the version plugin. You can install it with "yarn plugin import version".` This error occurs because the workflow is trying to use the yarn version command, but the version plugin isn't installed in your Yarn environment.
To fix this, you need to import the version plugin before using the yarn version command by adding the yarn plugin import version event

## Screenshots
<!-- Required if you are making UI changes. -->
<!-- *None* -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
<!-- *None* -->

## Other
<!-- Anything not covered above -->
<!-- *None* -->
